### PR TITLE
use $(MAKE) instead of make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ export V?=0
 
 .PHONY: all
 all:
-	make -C host CROSS_COMPILE="$(HOST_CROSS_COMPILE)"
-	make -C ta CROSS_COMPILE="$(TA_CROSS_COMPILE)"
+	$(MAKE) -C host CROSS_COMPILE="$(HOST_CROSS_COMPILE)"
+	$(MAKE) -C ta CROSS_COMPILE="$(TA_CROSS_COMPILE)"
 
 .PHONY: clean
 clean:
-	make -C host clean
-	make -C ta clean
+	$(MAKE) -C host clean
+	$(MAKE) -C ta clean


### PR DESCRIPTION
Make parallel builds more robust and avoid dependency errors.

Signed-off-by: Victor Chong victor.chong@linaro.org
Tested-by: Victor Chong victor.chong@linaro.org (hikey)
