### PR TITLE
Android.mk: Fix filename mismatch

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -12,7 +12,7 @@ include $(CLEAR_VARS)
 LOCAL_CFLAGS += -DANDROID_BUILD
 LOCAL_CFLAGS += -Wall
 
-LOCAL_SRC_FILES += host/hello_world.c
+LOCAL_SRC_FILES += host/main.c
 
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/ta/include \
 		$(CFG_TEEC_PUBLIC_INCLUDE) \


### PR DESCRIPTION
This repo was a combination of both
https://github.com/jenswi-linaro/lcu14_optee_hello_world
and
https://github.com/jbech-linaro/template_ta

hello_world.c in Android.mk was from lcu14_optee_hello_world and
main.c in host/ came from template_ta.

Signed-off-by: Victor Chong <victor.chong@linaro.org>