### PR TITLE
ta/Makefile: clean should not fail when ta_dev_kit.mk is not found

### DIFF
--- a/ta/Makefile
+++ b/ta/Makefile
@@ -4,4 +4,10 @@ CPPFLAGS += -DCFG_TEE_TA_LOG_LEVEL=$(CFG_TEE_TA_LOG_LEVEL)
 # The UUID for the Trusted Application
 BINARY=8aaaf200-2450-11e4-abe2-0002a5d5c51b
 
-include $(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk
+-include $(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk
+
+ifeq ($(wildcard $(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk), )
+clean:
+	@echo 'Note: $$(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk not found, cannot clean TA'
+	@echo 'Note: TA_DEV_KIT_DIR=$(TA_DEV_KIT_DIR)'
+endif


### PR DESCRIPTION
'make clean' fails if it is run for the TA, but the OP-TEE dev kit file
is not found (which can occur if optee_os was cleaned already).
Deal with this case explicitly: print a message saying that the TA
cannot be clean, but don't cause an error.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>