### PR TITLE
host/Makefile: move $(LDADD) after object file

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -18,7 +18,7 @@ BINARY=hello_world
 all: $(BINARY)
 
 $(BINARY): $(OBJS)
-	$(CC) $(LDADD) -o $@ $<
+	$(CC) -o $@ $< $(LDADD)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Libraries should generally be provided after the object file(s). Doing
so fixes the following error (may depend on the compiler/linker used):

$ arm-linux-gnueabihf-gcc -lteec \
  -L/home/guest/optee_repo/build/../optee_client/out/export/lib \
  -o hello_world main.o
main.o: In function `main':
main.c:(.text+0x30): undefined reference to `TEEC_InitializeContext'
main.c:(.text+0x68): undefined reference to `TEEC_OpenSession'
main.c:(.text+0xba): undefined reference to `TEEC_InvokeCommand'
main.c:(.text+0xee): undefined reference to `TEEC_CloseSession'
main.c:(.text+0xf8): undefined reference to `TEEC_FinalizeContext'
collect2: error: ld returned 1 exit status
$ arm-linux-gnueabihf-gcc -o hello_world main.o -lteec \
  -L/home/guest/optee_repo/build/../optee_client/out/export/lib
$

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>